### PR TITLE
FIX : the base rabbitMQ link won't work witout the terminal slash.

### DIFF
--- a/psc-admin-portal/src/app/suivi-des-executions/suivi-des-executions.component.html
+++ b/psc-admin-portal/src/app/suivi-des-executions/suivi-des-executions.component.html
@@ -66,7 +66,7 @@
         </a>
       </p>
       <p>
-        <a href="/portal/tool/rabbitmq" target="_blank" class="btn--icon-before external-link">
+        <a href="/portal/tool/rabbitmq/" target="_blank" class="btn--icon-before external-link">
           <svg class="svg-icon svg-angle-right" aria-hidden="true" focusable="false">
             <use xlink:href="svg-icons/icon-sprite.svg#angle-right"></use>
           </svg>


### PR DESCRIPTION
Closes #70 