### PR TITLE
Switch back to PCKE as configured by PSC

### DIFF
--- a/server/oidc.conf
+++ b/server/oidc.conf
@@ -22,8 +22,6 @@ OIDCClientID ${CLIENT_ID}
 OIDCClientSecret ${CLIENT_SECRET}
 OIDCCryptoPassphrase "exec:/bin/bash -c \"head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32\""
 OIDCScope "openid scope_all"
-# ProSanteConnect doesn't support PKCE, so we need to inhibit it.
-OIDCPKCEMethod none
 
 OIDCWhiteListedClaims SubjectNameID given_name family_name
 


### PR DESCRIPTION
Fusionner cette PR quand l'instance de production ProSantéConnect aura reçu le correctif testé sur le BAS le 24/10/2024.

Closes #97 