### PR TITLE
Test JDK version to fail graciously if > 17, then use the dev.cfg specified JDK to run services that need it.

### DIFF
--- a/scripts/backend_setup.sh
+++ b/scripts/backend_setup.sh
@@ -28,5 +28,7 @@ if [ -z ${OLD_PWD} ]; then
   cd ${OLD_PWD}
 fi
 
+. ${SCRIPT_DIR}/dev.cfg
+
 export API_PORT=8080
 export RASS_LOAD_PORT=8082

--- a/scripts/launch_dev_backends.sh
+++ b/scripts/launch_dev_backends.sh
@@ -21,6 +21,17 @@
 
 . $(dirname $0)/backend_setup.sh
 
+if [ -z PS_API_JDK_HOME ]; then 
+  PS_API_JDK_HOME=$JAVA_HOME
+fi
+JDK_VERSION=$($PS_API_JDK_HOME/bin/java -version 2>&1 | grep -E "(java|openjdk) version \"" | sed -r "s/(java|openjdk) version \"([0-9]+)\..*/\2/g")
+if [ $JDK_VERSION -gt 17 ]; then
+  echo "With JDK version ${DEFAULT_JDK_VERSION} > 17, psc-ps-api run will fail, please set PS_API_JDK_HOME in dev.cfg"
+  exit 2
+else
+  echo "psc-ps-api run from $PS_API_JDK_HOME ($JDK_VERSION)"
+fi
+
 ${SCRIPT_DIR}/stop_dev_backends.sh
 
 touch ${SCRIPT_DIR}/dev.cfg
@@ -32,11 +43,11 @@ fi
 echo "Reaching to interface ${HOST_ADDRESS} for mongodb. Add HOST_ADRESS in scripts/dev.cfg to override."
 
 cd ${CODE_BASE_DIR}/psc-ps-api
-mvn spring-boot:run -Dspring-boot.run.jvmArguments="-Dserver.port=${API_PORT} -Dspring.data.mongodb.host=${HOST_ADDRESS}" &
+JAVA_HOME=${PS_API_JDK_HOME} mvn spring-boot:run -Dspring-boot.run.jvmArguments="-Dserver.port=${API_PORT} -Dspring.data.mongodb.host=${HOST_ADDRESS}" &
 echo $! > ${SCRIPT_DIR}/api.pid
 
 cd ${CODE_BASE_DIR}/psc-toggle-ids/psc-toggle-manager
-mvn spring-boot:run -D"spring-boot.run.jvmArguments=-Dserver.port=8081 -Dapi.base.url=http://${HOST_ADDRESS}:${API_PORT}/psc-api-maj/api" &
+JAVA_HOME=${PS_API_JDK_HOME} mvn spring-boot:run -D"spring-boot.run.jvmArguments=-Dserver.port=8081 -Dapi.base.url=http://${HOST_ADDRESS}:${API_PORT}/psc-api-maj/api" &
 echo $! > ${SCRIPT_DIR}/toggle.pid
 
 PSCLOAD_FILES_DIR=${SCRIPT_DIR}/../target/pscload_files
@@ -45,7 +56,7 @@ if [ ! -d ${PSCLOAD_FILES_DIR} ]; then
 fi
 
 cd ${CODE_BASE_DIR}/psc-rass-loader/pscload
-mvn spring-boot:run -D"spring-boot.run.jvmArguments=-Dserver.port=${RASS_LOAD_PORT} -Dserver.servlet.context-path=/pscload/v2 -Dapi.base.url=http://${HOST_ADDRESS}:${API_PORT}/psc-api-maj/api -Dextract.download.url=http://${HOST_ADDRESS}:9094/rass-archive-mock.zip -Duse.x509.auth=false -Dfiles.directory=${PSCLOAD_FILES_DIR}" &
+JAVA_HOME=${PS_API_JDK_HOME} mvn spring-boot:run -D"spring-boot.run.jvmArguments=-Dserver.port=${RASS_LOAD_PORT} -Dserver.servlet.context-path=/pscload/v2 -Dapi.base.url=http://${HOST_ADDRESS}:${API_PORT}/psc-api-maj/api -Dextract.download.url=http://${HOST_ADDRESS}:9094/rass-archive-mock.zip -Duse.x509.auth=false -Dfiles.directory=${PSCLOAD_FILES_DIR}" &
 echo $! > ${SCRIPT_DIR}/psload.pid
 
 cd ${CODE_BASE_DIR}/psc-extract


### PR DESCRIPTION
Closes #100 
And my current dev needed this for testing as I've switched to JDK21.